### PR TITLE
Fix bug: Unable to find image 'github.com/pythonstock/stock/tensorflow-py3-stock:latest' locally

### DIFF
--- a/docker/startStock.sh
+++ b/docker/startStock.sh
@@ -7,12 +7,12 @@ if [ $HAS_TF -lt 2 ];then
 fi
 
 HAS_TF_BASE=`docker images github.com/pythonstock/stock/tensorflow-py3 | wc -l `
-if [ $HAS_TF -lt 2 ];then
+if [ $HAS_TF_BASE -lt 2 ];then
     sh buildBase.sh
 fi
 
-HAS_TF_BASE=`docker images github.com/pythonstock/stock/tensorflow-py3-stock | wc -l `
-if [ $HAS_TF -lt 2 ];then
+HAS_TF_STOCK=`docker images github.com/pythonstock/stock/tensorflow-py3-stock | wc -l `
+if [ $HAS_TF_STOCK -lt 2 ];then
     sh buildStock.sh
 fi
 


### PR DESCRIPTION
当我本机已存在tensorflow的latest-devel镜像时，执行startStock.sh就会报错。